### PR TITLE
feat: stage-1 local rank matcher MVP

### DIFF
--- a/rank_matcher/README.md
+++ b/rank_matcher/README.md
@@ -1,0 +1,50 @@
+# rank_matcher
+
+本地 MVP 工具：识别今日上线新剧，并匹配其在免费榜/付费榜的小时排名。
+
+## 1. 项目用途
+- 扫描 `data/input/` 自动识别最新输入文件
+- 筛选目标日期上架新剧
+- 生成免费榜/付费榜排名并匹配
+- 输出 Excel + JSON
+
+## 2. 文件命名规则
+- 漫剧导出：文件名包含 `漫剧导出`
+- 免费榜：文件名包含 `免费漫剧`
+- 付费榜：文件名包含 `付费漫剧`
+- 支持 `.xlsx/.xls/.csv`，同类多个取最新修改时间
+
+## 3. 字段要求
+- 漫剧导出必需：`短剧ID` `短剧名称` `上架时间`
+- 榜单必需：`剧ID` `剧名`
+- alias_map 可选：`短剧ID` `标准剧名` `别名`
+
+## 4. 配置
+见 `config.yaml`：输入目录、文件关键词、输出路径、模糊阈值、默认日期。
+
+## 5. 运行
+```bash
+python main.py
+python main.py --date 2026-05-02
+python main.py --input-dir data/input --date 2026-05-02
+python main.py --launch "...xlsx" --free "...xlsx" --paid "...xlsx" --date 2026-05-02
+```
+
+## 6. 匹配逻辑
+1) ID 精确匹配
+2) 标准化剧名精确匹配
+3) alias_map 别名匹配
+4) rapidfuzz 模糊匹配（低于阈值标记人工确认）
+
+## 7. 榜单排名规则
+按有效数据行顺序从 1 开始；空行与 ID/剧名都为空的行不计入。
+
+## 8. 输出说明
+- Excel: `data/output/rank_match_result.xlsx`
+- JSON: `data/output/rank_match_result.json`
+包含 summary 与 items，便于后续分析。
+
+## 9. 常见错误
+- 输入目录不存在
+- 找不到某类文件
+- 缺少必要字段

--- a/rank_matcher/config.yaml
+++ b/rank_matcher/config.yaml
@@ -1,0 +1,18 @@
+input:
+  input_dir: data/input
+  alias_map_file: data/input/alias_map.csv
+
+file_patterns:
+  launch_file_keyword: "漫剧导出"
+  free_rank_keyword: "免费漫剧"
+  paid_rank_keyword: "付费漫剧"
+
+output:
+  excel_file: data/output/rank_match_result.xlsx
+  json_file: data/output/rank_match_result.json
+
+matching:
+  fuzzy_threshold: 90
+
+date:
+  target_date: null

--- a/rank_matcher/main.py
+++ b/rank_matcher/main.py
@@ -1,0 +1,133 @@
+import argparse
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from src.exporter import export_results
+from src.file_finder import FileFinderError, find_latest_file
+from src.matcher import build_alias_lookup, build_lookup, match_one
+from src.rank_builder import build_rank
+from src.reader import ReaderError, read_alias_map, read_launch_file, read_rank_file
+from src.summary import build_summary
+
+
+def resolve_target_date(cli_date, cfg_date):
+    if cli_date:
+        return cli_date
+    if cfg_date:
+        return cfg_date
+    return date.today().isoformat()
+
+
+def filter_launch_today(df, target_date):
+    dt = pd.to_datetime(df["上架时间"], errors="coerce")
+    return df[dt.dt.strftime("%Y-%m-%d") == target_date].copy()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date")
+    parser.add_argument("--input-dir")
+    parser.add_argument("--launch")
+    parser.add_argument("--free")
+    parser.add_argument("--paid")
+    args = parser.parse_args()
+
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    input_dir = args.input_dir or cfg["input"]["input_dir"]
+    target_date = resolve_target_date(args.date, cfg["date"].get("target_date"))
+
+    try:
+        launch_file = Path(args.launch) if args.launch else find_latest_file(input_dir, cfg["file_patterns"]["launch_file_keyword"])
+        free_file = Path(args.free) if args.free else find_latest_file(input_dir, cfg["file_patterns"]["free_rank_keyword"])
+        paid_file = Path(args.paid) if args.paid else find_latest_file(input_dir, cfg["file_patterns"]["paid_rank_keyword"])
+    except FileFinderError as e:
+        raise SystemExit(str(e))
+
+    if launch_file is None:
+        raise SystemExit("未找到漫剧导出文件")
+    if free_file is None:
+        raise SystemExit("未找到免费榜文件")
+    if paid_file is None:
+        raise SystemExit("未找到付费榜文件")
+
+    try:
+        launch_df = read_launch_file(launch_file)
+        free_df = read_rank_file(free_file, "免费")
+        paid_df = read_rank_file(paid_file, "付费")
+        alias_df = read_alias_map(cfg["input"]["alias_map_file"])
+    except ReaderError as e:
+        raise SystemExit(str(e))
+
+    today_df = filter_launch_today(launch_df, target_date)
+    free_rank_df, free_dup_id, free_dup_name = build_rank(free_df, "免费榜排名")
+    paid_rank_df, paid_dup_id, paid_dup_name = build_rank(paid_df, "付费榜排名")
+
+    free_by_id, free_by_name = build_lookup(free_rank_df, "免费榜排名")
+    paid_by_id, paid_by_name = build_lookup(paid_rank_df, "付费榜排名")
+    alias_lookup = build_alias_lookup(alias_df)
+    fuzzy_threshold = int(cfg["matching"]["fuzzy_threshold"])
+
+    rows = []
+    for _, row in today_df.iterrows():
+        did = str(row.get("短剧ID", "")).strip()
+        dname = str(row.get("短剧名称", "")).strip()
+
+        free_match = match_one(did, dname, free_by_id, free_by_name, alias_lookup, fuzzy_threshold)
+        paid_match = match_one(did, dname, paid_by_id, paid_by_name, alias_lookup, fuzzy_threshold)
+
+        anomalies = []
+        if free_match.rank is None:
+            anomalies.append("免费榜未上榜")
+        if paid_match.rank is None:
+            anomalies.append("付费榜未上榜")
+        if free_match.need_manual_check:
+            anomalies.append("免费榜匹配置信度较低，需人工确认")
+        if paid_match.need_manual_check:
+            anomalies.append("付费榜匹配置信度较低，需人工确认")
+        if free_dup_id:
+            anomalies.append("免费榜存在重复剧ID，需人工确认")
+        if free_dup_name:
+            anomalies.append("免费榜存在重复剧名，需人工确认")
+        if paid_dup_id:
+            anomalies.append("付费榜存在重复剧ID，需人工确认")
+        if paid_dup_name:
+            anomalies.append("付费榜存在重复剧名，需人工确认")
+
+        rows.append({
+            "目标日期": target_date,
+            "短剧ID": did,
+            "短剧名称": dname,
+            "上架时间": row.get("上架时间", ""),
+            "男/女频": row.get("男/女频", ""),
+            "版权方": row.get("版权方", ""),
+            "总集数": row.get("总集数", ""),
+            "免费榜排名": free_match.rank if free_match.rank is not None else "未上榜",
+            "付费榜排名": paid_match.rank if paid_match.rank is not None else "未上榜",
+            "免费榜匹配方式": free_match.method,
+            "付费榜匹配方式": paid_match.method,
+            "免费榜匹配置信度": free_match.confidence,
+            "付费榜匹配置信度": paid_match.confidence,
+            "是否需要人工确认": "是" if (free_match.need_manual_check or paid_match.need_manual_check) else "否",
+            "异常说明": "；".join(anomalies) if anomalies else "正常",
+        })
+
+    if len(rows) == 0:
+        rows = []
+
+    summary = build_summary(target_date, rows, {
+        "launch_file": launch_file.name,
+        "free_rank_file": free_file.name,
+        "paid_rank_file": paid_file.name,
+    })
+
+    export_results(rows, cfg["output"]["excel_file"], cfg["output"]["json_file"], summary)
+    print("完成：", cfg["output"]["excel_file"], cfg["output"]["json_file"])
+
+
+if __name__ == "__main__":
+    main()

--- a/rank_matcher/requirements.txt
+++ b/rank_matcher/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=2.0.0
+openpyxl>=3.1.0
+pyyaml>=6.0
+rapidfuzz>=3.0.0
+pytest>=8.0.0

--- a/rank_matcher/src/exporter.py
+++ b/rank_matcher/src/exporter.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+import pandas as pd
+
+
+def export_results(rows, excel_path: str, json_path: str, summary: dict):
+    excel_p = Path(excel_path)
+    json_p = Path(json_path)
+    excel_p.parent.mkdir(parents=True, exist_ok=True)
+    json_p.parent.mkdir(parents=True, exist_ok=True)
+
+    pd.DataFrame(rows).to_excel(excel_p, index=False)
+
+    items = []
+    for r in rows:
+        items.append({
+            "target_date": r["目标日期"],
+            "drama_id": r["短剧ID"],
+            "drama_name": r["短剧名称"],
+            "launch_time": str(r["上架时间"]),
+            "gender_channel": r.get("男/女频", ""),
+            "copyright_owner": r.get("版权方", ""),
+            "total_episodes": r.get("总集数", ""),
+            "free_rank": r["免费榜排名"],
+            "paid_rank": r["付费榜排名"],
+            "free_match_method": r["免费榜匹配方式"],
+            "paid_match_method": r["付费榜匹配方式"],
+            "free_confidence": r["免费榜匹配置信度"],
+            "paid_confidence": r["付费榜匹配置信度"],
+            "need_manual_check": r["是否需要人工确认"] == "是",
+            "anomaly_reason": r["异常说明"],
+        })
+
+    with open(json_p, "w", encoding="utf-8") as f:
+        json.dump({"summary": summary, "items": items}, f, ensure_ascii=False, indent=2)

--- a/rank_matcher/src/file_finder.py
+++ b/rank_matcher/src/file_finder.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Optional
+
+SUPPORTED_EXTS = {".xlsx", ".xls", ".csv"}
+
+
+class FileFinderError(Exception):
+    pass
+
+
+def find_latest_file(input_dir: str, keyword: str) -> Optional[Path]:
+    base = Path(input_dir)
+    if not base.exists():
+        raise FileFinderError(f"输入目录不存在: {input_dir}")
+    if not base.is_dir():
+        raise FileFinderError(f"输入路径不是目录: {input_dir}")
+
+    candidates = [
+        p for p in base.iterdir()
+        if p.is_file() and keyword in p.name and p.suffix.lower() in SUPPORTED_EXTS
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)

--- a/rank_matcher/src/matcher.py
+++ b/rank_matcher/src/matcher.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from rapidfuzz import fuzz
+
+from .normalizer import normalize_title
+
+
+@dataclass
+class MatchResult:
+    rank: Optional[int]
+    method: str
+    confidence: int
+    need_manual_check: bool
+
+
+def build_lookup(rank_df, rank_col: str):
+    by_id = {}
+    by_name = {}
+    for _, row in rank_df.iterrows():
+        drama_id = str(row.get("剧ID", "")).strip()
+        drama_name = str(row.get("剧名", "")).strip()
+        norm = normalize_title(drama_name)
+        if drama_id and drama_id not in by_id:
+            by_id[drama_id] = int(row[rank_col])
+        if norm and norm not in by_name:
+            by_name[norm] = int(row[rank_col])
+    return by_id, by_name
+
+
+def build_alias_lookup(alias_df):
+    alias_to_id = {}
+    if alias_df is None:
+        return alias_to_id
+    for _, row in alias_df.iterrows():
+        aid = str(row.get("短剧ID", "")).strip()
+        alias = normalize_title(str(row.get("别名", "")).strip())
+        if aid and alias:
+            alias_to_id[alias] = aid
+    return alias_to_id
+
+
+def match_one(drama_id: str, drama_name: str, by_id: Dict[str, int], by_name: Dict[str, int],
+              alias_to_id: Dict[str, str], fuzzy_threshold: int) -> MatchResult:
+    did = str(drama_id).strip()
+    norm_name = normalize_title(drama_name)
+
+    if did and did in by_id:
+        return MatchResult(by_id[did], "id_exact", 100, False)
+    if norm_name and norm_name in by_name:
+        return MatchResult(by_name[norm_name], "title_exact", 100, False)
+    if norm_name and norm_name in alias_to_id:
+        alias_id = alias_to_id[norm_name]
+        if alias_id in by_id:
+            return MatchResult(by_id[alias_id], "alias_map", 100, False)
+
+    best_name = None
+    best_score = -1
+    for candidate in by_name.keys():
+        score = fuzz.ratio(norm_name, candidate)
+        if score > best_score:
+            best_score = score
+            best_name = candidate
+    if best_name is None:
+        return MatchResult(None, "unmatched", 0, False)
+
+    rank = by_name[best_name]
+    need_manual = best_score < fuzzy_threshold
+    return MatchResult(rank, "fuzzy", int(best_score), need_manual)

--- a/rank_matcher/src/normalizer.py
+++ b/rank_matcher/src/normalizer.py
@@ -1,0 +1,14 @@
+import re
+import unicodedata
+
+
+def normalize_title(title: str) -> str:
+    if title is None:
+        return ""
+    s = str(title)
+    s = unicodedata.normalize("NFKC", s)
+    s = s.strip().lower()
+    s = s.replace("《", "").replace("》", "").replace("<", "").replace(">", "")
+    s = re.sub(r"[\s\u3000]+", "", s)
+    s = re.sub(r"[\.,，。!！\?？:：;；\-—_~`'\"“”‘’\(\)（）\[\]【】{}、/\\|]+", "", s)
+    return s

--- a/rank_matcher/src/rank_builder.py
+++ b/rank_matcher/src/rank_builder.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+
+def build_rank(df: pd.DataFrame, rank_name: str):
+    out = []
+    rank = 0
+    duplicate_id = False
+    duplicate_name = False
+
+    ids = df["剧ID"].fillna("").astype(str).str.strip()
+    names = df["剧名"].fillna("").astype(str).str.strip()
+
+    valid = ~((ids == "") & (names == ""))
+    seen_id = set()
+    seen_name = set()
+
+    for _, row in df[valid].iterrows():
+        drama_id = str(row.get("剧ID", "")).strip()
+        drama_name = str(row.get("剧名", "")).strip()
+        rank += 1
+        out.append({"剧ID": drama_id, "剧名": drama_name, rank_name: rank})
+
+        if drama_id:
+            if drama_id in seen_id:
+                duplicate_id = True
+            seen_id.add(drama_id)
+        if drama_name:
+            if drama_name in seen_name:
+                duplicate_name = True
+            seen_name.add(drama_name)
+
+    return pd.DataFrame(out), duplicate_id, duplicate_name

--- a/rank_matcher/src/reader.py
+++ b/rank_matcher/src/reader.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import pandas as pd
+
+LAUNCH_REQUIRED = ["短剧ID", "短剧名称", "上架时间"]
+RANK_REQUIRED = ["剧ID", "剧名"]
+
+
+class ReaderError(Exception):
+    pass
+
+
+def _read_any(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".csv":
+        return pd.read_csv(path)
+    return pd.read_excel(path)
+
+
+def read_launch_file(path: Path) -> pd.DataFrame:
+    df = _read_any(path)
+    missing = [c for c in LAUNCH_REQUIRED if c not in df.columns]
+    if missing:
+        raise ReaderError(f"漫剧导出文件缺少必要字段: {','.join(missing)}")
+    return df
+
+
+def read_rank_file(path: Path, rank_type: str) -> pd.DataFrame:
+    df = _read_any(path)
+    missing = [c for c in RANK_REQUIRED if c not in df.columns]
+    if missing:
+        raise ReaderError(f"{rank_type}榜文件缺少必要字段: {','.join(missing)}")
+    return df
+
+
+def read_alias_map(path: str):
+    p = Path(path)
+    if not p.exists():
+        return None
+    df = pd.read_csv(p)
+    for col in ["短剧ID", "标准剧名", "别名"]:
+        if col not in df.columns:
+            raise ReaderError(f"alias_map.csv 缺少字段: {col}")
+    return df

--- a/rank_matcher/src/summary.py
+++ b/rank_matcher/src/summary.py
@@ -1,0 +1,17 @@
+def build_summary(target_date, rows, source_files):
+    launch_count = len(rows)
+    free_ranked_count = sum(1 for r in rows if r["免费榜排名"] != "未上榜")
+    paid_ranked_count = sum(1 for r in rows if r["付费榜排名"] != "未上榜")
+    both_ranked_count = sum(1 for r in rows if r["免费榜排名"] != "未上榜" and r["付费榜排名"] != "未上榜")
+    unranked_count = sum(1 for r in rows if r["免费榜排名"] == "未上榜" and r["付费榜排名"] == "未上榜")
+    manual_check_count = sum(1 for r in rows if r["是否需要人工确认"] == "是")
+    return {
+        "target_date": target_date,
+        "launch_count": launch_count,
+        "free_ranked_count": free_ranked_count,
+        "paid_ranked_count": paid_ranked_count,
+        "both_ranked_count": both_ranked_count,
+        "unranked_count": unranked_count,
+        "manual_check_count": manual_check_count,
+        "source_files": source_files,
+    }

--- a/rank_matcher/tests/test_file_finder.py
+++ b/rank_matcher/tests/test_file_finder.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import time
+
+from src.file_finder import find_latest_file
+
+
+def test_find_latest_files(tmp_path: Path):
+    f1 = tmp_path / "漫剧导出_a.xlsx"
+    f1.write_text("x")
+    time.sleep(0.01)
+    f2 = tmp_path / "漫剧导出_b.csv"
+    f2.write_text("x")
+    assert find_latest_file(str(tmp_path), "漫剧导出") == f2

--- a/rank_matcher/tests/test_matcher.py
+++ b/rank_matcher/tests/test_matcher.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from src.matcher import build_alias_lookup, build_lookup, match_one
+
+
+def test_id_exact_title_alias_fuzzy():
+    rank_df = pd.DataFrame([
+        {"剧ID": "100", "剧名": "总裁的替嫁新娘", "免费榜排名": 1},
+        {"剧ID": "200", "剧名": "霸道总裁爱上我", "免费榜排名": 2},
+    ])
+    by_id, by_name = build_lookup(rank_df, "免费榜排名")
+    alias_df = pd.DataFrame([{"短剧ID": "100", "标准剧名": "总裁的替嫁新娘", "别名": "替嫁新娘"}])
+    alias = build_alias_lookup(alias_df)
+
+    assert match_one("100", "x", by_id, by_name, alias, 90).method == "id_exact"
+    assert match_one("", "总裁的替嫁新娘", by_id, by_name, alias, 90).method == "title_exact"
+    assert match_one("", "替嫁新娘", by_id, by_name, alias, 90).method == "alias_map"
+    low = match_one("", "完全不一样", by_id, by_name, alias, 95)
+    assert low.method == "fuzzy"
+    assert low.need_manual_check

--- a/rank_matcher/tests/test_normalizer.py
+++ b/rank_matcher/tests/test_normalizer.py
@@ -1,0 +1,5 @@
+from src.normalizer import normalize_title
+
+
+def test_normalize_title():
+    assert normalize_title("《 总裁 的替嫁新娘 》") == "总裁的替嫁新娘"

--- a/rank_matcher/tests/test_rank_builder.py
+++ b/rank_matcher/tests/test_rank_builder.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from src.rank_builder import build_rank
+
+
+def test_rank_build_and_skip_empty():
+    df = pd.DataFrame({"剧ID": ["1", "", "2"], "剧名": ["A", "", "B"]})
+    out, dup_id, dup_name = build_rank(df, "免费榜排名")
+    assert list(out["免费榜排名"]) == [1, 2]
+    assert not dup_id
+    assert not dup_name


### PR DESCRIPTION
### Motivation
- Provide a local MVP tool to automatically find today’s newly launched dramas and match them against hourly free/paid ranking sheets for quick hourly review. 
- Keep everything local and configurable with no external APIs, and produce both Excel and JSON outputs for downstream analysis.

### Description
- Add a complete project scaffold `rank_matcher/` with `main.py`, `config.yaml`, `requirements.txt`, `README.md`, core modules under `src/` and unit tests under `tests/`. 
- Implement file discovery with `find_latest_file` in `src/file_finder.py` to auto-detect latest files by keyword and extension. 
- Implement readers and validation in `src/reader.py`, title normalization in `src/normalizer.py`, rank generation in `src/rank_builder.py`, matching pipeline in `src/matcher.py` (ID/title/alias/fuzzy using `rapidfuzz`), summary aggregation in `src/summary.py`, and export to Excel/JSON in `src/exporter.py`. 
- Provide CLI in `main.py` supporting `--date`, `--input-dir` and manual file overrides `--launch/--free/--paid`, and use `config.yaml` for defaults and `matching.fuzzy_threshold`.

### Testing
- Added unit tests for latest-file detection, title normalization, rank building (skip empty rows), and matching priority under `tests/` (`test_file_finder.py`, `test_normalizer.py`, `test_rank_builder.py`, `test_matcher.py`).
- Executing `pytest -q` in the running environment failed during collection with `ModuleNotFoundError` for `src` and missing `pandas`, so tests did not complete. 
- Attempting `python -m pip install -r requirements.txt` failed due to network/proxy errors (could not download `pandas`), so install dependencies locally and re-run `pytest` to validate the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f5898267408326be6a6106532de550)